### PR TITLE
Update workflow to only trigger for members/owners

### DIFF
--- a/.github/workflows/pr-image.yml
+++ b/.github/workflows/pr-image.yml
@@ -8,8 +8,7 @@ jobs:
 
     if: |
       github.event.issue.pull_request && contains(github.event.comment.body, '/build-docker-image') &&
-      ( github.event.comment.author_association == 'CONTRIBUTOR' || 
-        github.event.comment.author_association == 'MEMBER' ||
+      ( github.event.comment.author_association == 'MEMBER' ||
         github.event.comment.author_association == 'OWNER' )
 
     steps:


### PR DESCRIPTION
Update the build-pr image to only trigger for members and owners
