### PR TITLE
Fixed 'arguments' parameter deprecation

### DIFF
--- a/.github/workflows/main-push.yml
+++ b/.github/workflows/main-push.yml
@@ -1,6 +1,6 @@
 name: Build Edge Image
 
-on: 
+on:
   push:
     branches: main
 
@@ -16,10 +16,11 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
+
       - name: Gradle Build
-        uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43 # v3.3.2
-        with:
-            arguments: distTar
+        run: ./gradlew distTar
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0

--- a/.github/workflows/pr-image.yml
+++ b/.github/workflows/pr-image.yml
@@ -27,10 +27,11 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
+
       - name: Gradle Build
-        uses: gradle/actions/setup-gradle@@3b1b3b9a2104c2b47fbae53f3938079c00c9bb87 # v3.0.0
-        with:
-            arguments: distTar
+        run: ./gradlew distTar
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v.3.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,11 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
+
       - name: Gradle Build
-        uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43 # v3.3.2
-        with:
-          arguments: distTar
+        run: ./gradlew distTar
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v.3.3.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,12 +22,10 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
+
       - name: Check
-        uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43 # v3.3.2
         env:
           DATABASE_HOST: localhost
-        with:
-          arguments: check
-
-
-
+        run: ./gradlew check


### PR DESCRIPTION
Current PR checks and builds are failing because Actions workflows that use `gradle/actions/setup-gradle` were using deprecated features so I fixed that up. Details here: https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated

## Requirements

You will need to sign the CLA if this is your first time contributing.

Please read the [Contributing guidelines](https://github.com/target/emoji_manager/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/target/.github/blob/main/CODE_OF_CONDUCT.md) before creating this issue or pull request. By submitting, you agree to those rules.