### PR TITLE
Chore: Upgrade project to java 21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ repositories {
 application {
     mainClass.set("com.target.slack.SlackApplicationKt")
     group = "com.target.slack"
-    java.sourceCompatibility = JavaVersion.VERSION_17
+    java.sourceCompatibility = JavaVersion.VERSION_21
 }
 
 configurations.all {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.code.style=official
-jvmTargetVersion = 17
+jvmTargetVersion = 21
 org.gradle.jvmargs=-Xmx2g
 kotlin.daemon.jvmargs=-Xmx2g
 org.gradle.workers.max=2


### PR DESCRIPTION
In PR #161, it upgrades the http4k library from 5.x to 6.x. In order for that to succeed, the project needs to use Java 21 so this PR ends up being a prereq to that.

I've ran this locally and everything looks good. We aren't cutting a release until dependencies are upgraded, deprecation warnings are fixed, and #162 is fixed so even if there's something minor not working, we'll catch it before the next release 

## Requirements

You will need to sign the CLA if this is your first time contributing.

Please read the [Contributing guidelines](https://github.com/target/emoji_manager/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/target/.github/blob/main/CODE_OF_CONDUCT.md) before creating this issue or pull request. By submitting, you agree to those rules.